### PR TITLE
Add DSPy-style output mapping

### DIFF
--- a/README
+++ b/README
@@ -14,10 +14,14 @@ This project provides a minimal web interface for experimenting with the OpenAI 
    npm start
    ```
 4. Navigate to <http://localhost:3000> in your browser.
+   The page displays the LLM reply as a JSON object with `prompt`, `context`
+   and `answer` fields.
 
 ## Files
 
 - `server.js` – Express server that proxies requests to OpenAI.
 - `public/index.html` – Minimal page with two text fields and a submit button.
+- `example.py` – Example Python script that calls the server and prints a
+  DSPy-style record.
 
 This example requires Node.js v16 or higher.

--- a/example.py
+++ b/example.py
@@ -1,0 +1,19 @@
+import requests
+import json
+
+SERVER_URL = "http://localhost:3000/api/respond"
+
+prompt = "Write a short poem about spring."
+context = "You are a helpful assistant."
+
+response = requests.post(SERVER_URL, json={"prompt": prompt, "context": context})
+response.raise_for_status()
+
+data = response.json()
+example = {
+    "prompt": prompt,
+    "context": context,
+    "answer": data["output"],
+}
+
+print(json.dumps(example, indent=2))

--- a/public/index.html
+++ b/public/index.html
@@ -28,10 +28,12 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt, context })
       });
-      if (res.ok) {
-        const data = await res.json();
-        document.getElementById('output').textContent = data.output;
-      } else {
+        if (res.ok) {
+          const data = await res.json();
+          const example = { prompt, context, answer: data.output };
+          document.getElementById('output').textContent =
+            JSON.stringify(example, null, 2);
+        } else {
         const err = await res.json();
         document.getElementById('output').textContent = err.error || 'Error';
       }


### PR DESCRIPTION
## Summary
- show the model response in DSPy format on the web page
- add a Python script to fetch the response and print the mapping
- document the new behavior and script in the README

## Testing
- `npm test` *(fails: Missing script)*