### PR TITLE
Swap prompt/context labels with placeholders

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,10 +11,10 @@
 </head>
 <body>
   <h1>OpenAI Response Demo</h1>
-  <label for="context">Context:</label>
-  <textarea id="context"></textarea>
-  <label for="prompt">Prompt:</label>
-  <textarea id="prompt"></textarea>
+  <label for="context">Prompt:</label>
+  <textarea id="context" placeholder="You are a helpful and knowledgeable weather assistant. Always provide accurate, clear, and up-to-date weather information and advice in a friendly, professional tone. You will be given a transcript from a weather announcer. Output the highs/lows, precipitation chances, weather warnings, wind speeds for each day in the next week"></textarea>
+  <label for="prompt">Context:</label>
+  <textarea id="prompt" placeholder="Looking ahead, Monday starts with a mix of sun and clouds, high of 23°C, low 14°C. Tuesday and Wednesday will be cooler, highs at 18°C, lows at 10°C, with 40% precipitation chances each day, and winds around 17 km/h. On Thursday, a heat advisory is in effect, high of 30°C, low of 19°C, light winds. Friday returns to fair weather, high 24°C, low 15°C. Saturday and Sunday: highs of 21–22°C, lows of 12–13°C, with a slight chance of afternoon showers Saturday."></textarea>
   <button id="submit">Send</button>
   <h2>Output</h2>
   <div id="output"></div>


### PR DESCRIPTION
## Summary
- swap the prompt and context labels on the web page
- preload weather example text as placeholders

## Testing
- `npm --version`
- `node -v`
